### PR TITLE
fix: dml was not committed

### DIFF
--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -102,8 +102,10 @@ export default class CloudSpannerDriver extends AbstractDriver<DriverLib, Driver
   }
 
   private async executeDml(db: Database, sql: string, opt): Promise<NSDatabase.IResult> {
-    const [rowCount] = await db.runTransactionAsync((transaction): Promise<RunUpdateResponse> => {
-      return transaction.runUpdate(sql);
+    const [rowCount] = await db.runTransactionAsync(async (transaction): Promise<RunUpdateResponse> => {
+      const count = await transaction.runUpdate(sql);
+      await transaction.commit();
+      return count;
     });
     return {
       cols: ['rowCount'],

--- a/src/ls/parser.ts
+++ b/src/ls/parser.ts
@@ -205,7 +205,7 @@ export class SpannerQueryParser {
   }
 
   static getQueryParts(query: string, splittingIndex: number, numChars: number = 1): Array<string> {
-    var statement: string = query.substring(0, splittingIndex);
+    var statement: string = query.substring(0, splittingIndex - 1);
     var restOfQuery: string = query.substring(splittingIndex + numChars);
     var result: Array<string> = [];
     if (statement != null) {


### PR DESCRIPTION
DML statements were executed but not committed.

Also: Strip the trailing semicolon from statements to prevent errors when executing a count query before the actual query.