### PR TITLE
feat: add connection options for emulator and add DDL support

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -8,13 +8,13 @@
       "minLength": 1
     },
     "instance": {
-      "title": "Cloud Spanner Instance ID",
+      "title": "Spanner Instance ID",
       "type": "string",
       "minLength": 2,
       "maxLength": 64
     },
     "database": {
-      "title": "Cloud Spanner Database ID",
+      "title": "Spanner Database ID",
       "type": "string",
       "minLength": 2,
       "maxLength": 30
@@ -22,6 +22,18 @@
     "credentialsKeyFile": {
       "title": "Credentials Key File (optional)",
       "$comment": "Specifying a credentials file is optional. If no file is specified, the default Google credentials on this environment will be used",
+      "type": "string"
+    },
+    "connectToEmulator": {
+      "title": "Connect to emulator",
+      "type": "boolean"
+    },
+    "emulatorHost": {
+      "title": "Emulator host",
+      "type": "string"
+    },
+    "emulatorPort": {
+      "title": "Emulator port",
       "type": "string"
     }
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-cloud-spanner-driver",
   "displayName": "Google Cloud Spanner Driver",
   "description": "Google Cloud Spanner Driver for SQLTools",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "engines": {
     "vscode": "^1.42.0"
   },

--- a/ui.schema.json
+++ b/ui.schema.json
@@ -1,4 +1,7 @@
 {
-  "ui:order": ["project", "instance", "database", "credentials"],
-  "credentials": { "ui:widget": "file" }
+  "ui:order": ["project", "instance", "database", "credentialsKeyFile", "useLocalEmulator"],
+  "credentialsKeyFile": { "ui:widget": "file", "ui:help": "Credentials file to use to connect to Cloud Spanner. This is only required if the connection should use other credentials than the default credentials of the environment. Ignored for emulator connections." },
+  "connectToEmulator": { "ui:help": "Connects to a Spanner emulator instance instead of to Google Cloud. The instance and database specified in the settings above will automatically be created on the emulator if these do not already exist. The emulator must have been started before you can connect to it." },
+  "emulatorHost": { "ui:help": "The host name where the emulator is running. Defaults to 'localhost', and is only required if 'Connect to emulator' is enabled and the emulator is not running on localhost." },
+  "emulatorPort": { "ui:help": "The port number where the emulator is running. Defaults to '9010', and is only required if 'Connect to emulator' is enabled and the emulator is not running on port 9010 (gRPC)." }
 }


### PR DESCRIPTION
- Adds connection options for the Spanner emulator without the need to set the environment variable SPANNER_EMULATOR_HOST.
- Automatically creates the instance and database that is referenced in the connection if the connection is for the emulator. This
  removes the need to manually create the instance and database on the emulator before you can connect and try out simple queries.
- Adds support for DDL statements.

Fixes #6
Fixes #7
